### PR TITLE
Create a changelog

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,12 @@ const urldecode = require( 'urldecode' );
 const request = require( 'request' );
 const _ = require( 'lodash' );
 
-const secretGitHubToken = process.env.GH_API_TOKEN;
+const headers = {
+  'Content-Type': 'application/json;charset=UTF-8',
+  'Authorization': `token ${process.env.GH_API_TOKEN}`,
+  'Accept': 'application/vnd.github.inertia-preview+json',
+  'User-Agent': 'request'
+};
 
 const encodeString = ( string ) => {
 	const input = string && string.length ? string : clipboardy.readSync();
@@ -29,12 +34,7 @@ const decodeString = ( string ) => {
 const projectColumns = ( projectId ) => {
 	const options = {
 		url: 'https://api.github.com/projects/1492664/columns',
-		headers: {
-			'Content-Type': 'application/json;charset=UTF-8',
-			'Authorization': `token ${secretGitHubToken}`,
-			'Accept': 'application/vnd.github.inertia-preview+json',
-			'User-Agent': 'request'
-		}
+		headers,
 	}
 
 	request( options, ( error, response, body ) => {
@@ -68,12 +68,7 @@ const getLabels = labels => {
 const getPullRequest = ( content_url ) => {
   const options = {
     url: content_url,
-    headers: {
-      'Content-Type': 'application/json;charset=UTF-8',
-      'Authorization': `token ${secretGitHubToken}`,
-      'Accept': 'application/vnd.github.inertia-preview+json',
-      'User-Agent': 'request'
-    }
+    headers
   }
 
   request( options, ( error, response, body ) => {
@@ -97,12 +92,7 @@ const getPullRequest = ( content_url ) => {
 const columnCards = ( columnId ) => {
 	const options = {
 		url: `https://api.github.com/projects/columns/${columnId}/cards`,
-		headers: {
-			'Content-Type': 'application/json;charset=UTF-8',
-			'Authorization': `token ${secretGitHubToken}`,
-			'Accept': 'application/vnd.github.inertia-preview+json',
-			'User-Agent': 'request'
-		}
+		headers
 	}
 
 	request( options, ( error, response, body ) => {

--- a/index.js
+++ b/index.js
@@ -9,8 +9,6 @@ const request = require( 'request' );
 const requestPromise = require('request-promise');
 const _ = require( 'lodash' );
 
-let collaborators = [];
-
 const headers = {
   'Content-Type': 'application/json;charset=UTF-8',
   'Authorization': `token ${process.env.GH_API_TOKEN}`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,11 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "bluebird": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
+      "integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw=="
+    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -363,6 +368,32 @@
         "uuid": "^3.1.0"
       }
     },
+    "request-promise": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.4.tgz",
+      "integrity": "sha512-8wgMrvE546PzbR5WbYxUQogUnUDfM0S7QIFZMID+J73vdFARkFy+HElj4T+MWYhpXwlLp0EQ8Zoj8xUA0he4Vg==",
+      "requires": {
+        "bluebird": "^3.5.0",
+        "request-promise-core": "1.1.2",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
+      "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
+      "requires": {
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        }
+      }
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -406,6 +437,11 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       }
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "strip-eof": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "commander": "^2.12.1",
     "lodash": "^4.17.10",
     "request": "^2.87.0",
+    "request-promise": "^4.2.4",
     "urldecode": "^1.0.1",
     "urlencode": "^1.1.0"
   }


### PR DESCRIPTION
Create a changelog. Here is wc-admin [Sprint 16](https://github.com/orgs/woocommerce/projects/2).

```
- Enhancement: Try: Extension Examples #2018 (Build, Documentation, Extensibility) 
- Dev: Add empty states for the Inbox and Orders panels #2037 (Activity Panel) 
- Dev: Make SummaryListPlaceholder height match SummaryNumber height #2088 (Components, Packages) 
- Dev: Transpile acorn-jsx package #2064 (Build) 
- Dev: Fixed: Order Status filter: <select> is not vertically aligned when Gutenberg is installed #1971 (Components, Packages) 👏 @dinhtungdu
- Dev: Add check for wp_set_script_translations. #2117  
- Dev: Respect manual offsets in default before/after params #2042 (REST API) 
- Dev: Allow free input in the table pagination input field #2091 (Components, Packages) 
- Dev: Add wcAdminAssetUrl property again in wcSettings #2075 (Analytics) 
- Dev: Extend report submenu items #2033 (Build, Extensibility) 
- Dev: Check if welcome message notice exists before creating it #2063 (Inbox) 
- Dev: Add empty state in Stock panel #2049 (Activity Panel) 
- Dev: Add customizable dashboard feature flag, and base page. #2052 (Build, Dashboard, Extensibility) 
- Dev: Use CSS variables in the Activity Panel and breadcrumbs CSS #2096 (Activity Panel)
```

### Features

* A type derived from the `[Type]` label (defaults to `dev`)
* Title
* Pull request number
* Additional labels
* Shoutout to PR author if they are not part of the WooCommerce org on github

### Testing instructions

1. `npm install`
2. export `GH_API_TOKEN` from bash profile
3. `./index.js columns` to select a column id
4. `./index.js changelog 4550956` to create the changelog